### PR TITLE
fix: do not crash when v is nil for polymorphic foreign key object

### DIFF
--- a/lib/jsonapi/resource_common.rb
+++ b/lib/jsonapi/resource_common.rb
@@ -1212,8 +1212,8 @@ module JSONAPI
       def define_foreign_key_setter(relationship)
         if relationship.polymorphic?
           define_on_resource "#{relationship.foreign_key}=" do |v|
-            _model.public_send("#{relationship.foreign_key}=", v[:id])
-            _model.public_send("#{relationship.polymorphic_type}=", self.class.polymorphic_type_for(v[:type]))
+            _model.public_send("#{relationship.foreign_key}=", v.try(:[], :id))
+            _model.public_send("#{relationship.polymorphic_type}=", self.class.polymorphic_type_for(v.try(:[], :type)))
           end
         else
           define_on_resource "#{relationship.foreign_key}=" do |value|


### PR DESCRIPTION
### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions

https://ontra-team.atlassian.net/browse/DOCS-518