### PR TITLE
ci: pull postgres service image through Nexus instead of Docker Hub

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,7 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres
+        image: docker-all.facts.ontra.tools/postgres
+        credentials:
+          username: ${{ secrets.NEXUS_USER_TOKEN_NAME_CODE }}
+          password: ${{ secrets.NEXUS_USER_TOKEN_PASS_CODE }}
         env:
           POSTGRES_PASSWORD: password
           POSTGRES_DB: test


### PR DESCRIPTION
Pull CI images through the Nexus proxy instead of Docker Hub to avoid Hub rate limits/auth outages (INFRA-2091).